### PR TITLE
✨ feat [#10-hashtag] 해시태그 CRUD Controller, DTO 생성

### DIFF
--- a/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/request/ReqHashtagPostDTOApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/request/ReqHashtagPostDTOApiV1.java
@@ -1,0 +1,29 @@
+package com.bookstore.post.hashtag.application.dto.v1.request;
+
+import com.bookstore.post.hashtag.domain.entity.HashtagEntity;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ReqHashtagPostDTOApiV1 {
+    @Valid
+    @NotNull(message = "해시태그 정보를 입력해주세요.")
+    private Hashtag hashtag;
+
+    public HashtagEntity createHashtag() {
+        return HashtagEntity.createHashtagEntity(
+            hashtag.getName()
+        );
+    }
+
+    @Builder
+    @Getter
+    public static class Hashtag {
+        @NotBlank(message = "해시태그 이름을 입력해주세요.")
+        private String name;
+    }
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/request/ReqHashtagPutDTOApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/request/ReqHashtagPutDTOApiV1.java
@@ -1,0 +1,16 @@
+package com.bookstore.post.hashtag.application.dto.v1.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReqHashtagPutDTOApiV1 {
+    private Hashtag hashtag;
+
+    @Getter
+    @Builder
+    public static class Hashtag {
+        private String name;
+    }
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagGetByIdDTOApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagGetByIdDTOApiV1.java
@@ -1,0 +1,29 @@
+package com.bookstore.post.hashtag.application.dto.v1.response;
+
+import com.bookstore.post.hashtag.domain.entity.HashtagEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResHashtagGetByIdDTOApiV1 {
+    private Hashtag hashtag;
+
+    public static ResHashtagGetByIdDTOApiV1 of(HashtagEntity hashtagEntity) {
+        return ResHashtagGetByIdDTOApiV1.builder()
+            .hashtag(Hashtag.from(hashtagEntity))
+            .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Hashtag{
+        private String name;
+
+        public static Hashtag from(HashtagEntity hashtagEntity) {
+            return Hashtag.builder()
+                .name(hashtagEntity.getName())
+                .build();
+        }
+    }
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagGetDTOApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagGetDTOApiV1.java
@@ -1,0 +1,54 @@
+package com.bookstore.post.hashtag.application.dto.v1.response;
+
+import com.bookstore.post.hashtag.domain.entity.HashtagEntity;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
+
+@Getter
+@Builder
+public class ResHashtagGetDTOApiV1 {
+    private HashtagPage hashtagPage;
+
+    public static ResHashtagGetDTOApiV1 of(
+        Page<HashtagEntity> hashtagEntityPage
+    ) {
+        return ResHashtagGetDTOApiV1.builder()
+            .hashtagPage(new HashtagPage(hashtagEntityPage))
+            .build();
+    }
+
+    @Getter
+    public static class HashtagPage extends PagedModel<HashtagPage.Hashtag> {
+        public HashtagPage(Page<HashtagEntity> hashtagEntityPage) {
+            super(
+                new PageImpl<>(
+                    Hashtag.from(hashtagEntityPage.getContent()),
+                    hashtagEntityPage.getPageable(),
+                    hashtagEntityPage.getTotalElements()
+                )
+            );
+        }
+
+        @Getter
+        @Builder
+        public static class Hashtag {
+            private String name;
+
+            public static List<Hashtag> from(List<HashtagEntity> hashtagEntityList) {
+                return hashtagEntityList.stream()
+                    .map(Hashtag::from)
+                    .toList();
+            }
+
+            public static Hashtag from(HashtagEntity hashtagEntity) {
+                return Hashtag.builder()
+                    .name(hashtagEntity.getName())
+                    .build();
+            }
+        }
+    }
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagPostDTOApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagPostDTOApiV1.java
@@ -1,0 +1,35 @@
+package com.bookstore.post.hashtag.application.dto.v1.response;
+
+import com.bookstore.post.hashtag.domain.entity.HashtagEntity;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ResHashtagPostDTOApiV1 {
+    @Valid
+    @NotNull(message = "해시태그 정보를 입력해주세요")
+    private Hashtag hashtag;
+
+    public static ResHashtagPostDTOApiV1 of(HashtagEntity hashtagEntity) {
+        return ResHashtagPostDTOApiV1.builder()
+            .hashtag(Hashtag.from(hashtagEntity))
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Hashtag {
+        @NotBlank(message = "해시태그 이름을 입력해주세요.")
+        private String name;
+
+        public static Hashtag from(HashtagEntity hashtagEntity) {
+            return Hashtag.builder()
+                .name(hashtagEntity.getName())
+                .build();
+        }
+    }
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagPutDTOApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/dto/v1/response/ResHashtagPutDTOApiV1.java
@@ -1,0 +1,29 @@
+package com.bookstore.post.hashtag.application.dto.v1.response;
+
+import com.bookstore.post.hashtag.domain.entity.HashtagEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResHashtagPutDTOApiV1 {
+    private Hashtag hashtag;
+
+    public static ResHashtagPutDTOApiV1 of(HashtagEntity hashtagEntity) {
+        return ResHashtagPutDTOApiV1.builder()
+            .hashtag(Hashtag.from(hashtagEntity))
+            .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Hashtag{
+        private String name;
+
+        public static Hashtag from(HashtagEntity hashtagEntity) {
+            return Hashtag.builder()
+                .name(hashtagEntity.getName())
+                .build();
+        }
+    }
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/domain/entity/HashtagEntity.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/domain/entity/HashtagEntity.java
@@ -1,0 +1,39 @@
+package com.bookstore.post.hashtag.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "p_hashtags")
+public class HashtagEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private HashtagEntity(String name) {
+        this.name = name;
+    }
+
+    public static HashtagEntity createHashtagEntity(
+        String name
+    ) {
+        return HashtagEntity.builder()
+            .name(name)
+            .build();
+    }
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/presentation/controller/v1/HashtagControllerApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/presentation/controller/v1/HashtagControllerApiV1.java
@@ -87,7 +87,7 @@ public class HashtagControllerApiV1 {
                 .code("0")
                 .message("해시태그 삭제에 성공했습니다.")
                 .build(),
-            HttpStatus.OK
+            HttpStatus.NO_CONTENT
         );
     }
 }

--- a/post/src/main/java/com/bookstore/post/hashtag/presentation/controller/v1/HashtagControllerApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/presentation/controller/v1/HashtagControllerApiV1.java
@@ -1,0 +1,93 @@
+package com.bookstore.post.hashtag.presentation.controller.v1;
+
+import com.bookstore.post.common.application.dto.ResDTO;
+import com.bookstore.post.hashtag.application.dto.v1.request.ReqHashtagPostDTOApiV1;
+import com.bookstore.post.hashtag.application.dto.v1.request.ReqHashtagPutDTOApiV1;
+import com.bookstore.post.hashtag.domain.entity.HashtagEntity;
+import java.util.UUID;
+import com.querydsl.core.types.Predicate;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/hashtags")
+public class HashtagControllerApiV1 {
+
+    @PostMapping
+    public ResponseEntity<ResDTO<Object>> postBy(
+        @RequestBody ReqHashtagPostDTOApiV1 dto
+    ) {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code("0")
+                .message("해시태그가 생성되었습니다.")
+                .build(),
+            HttpStatus.CREATED
+        );
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResDTO<Object>> getBy(
+        @PathVariable UUID id
+    ) {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code("0")
+                .message("해시태그 단건 조회에 성공했습니다.")
+                .build(),
+            HttpStatus.OK
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResDTO<Object>> getBy(
+        @QuerydslPredicate(root = HashtagEntity.class) Predicate predicate,
+        @PageableDefault(page = 0, size = 10) Pageable pageable
+    ) {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code("0")
+                .message("해시태그 리스트 조회에 성공했습니다.")
+                .build(),
+            HttpStatus.OK
+        );
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResDTO<Object>> putBy(
+        @PathVariable UUID id,
+        @RequestBody ReqHashtagPutDTOApiV1 dto
+    ) {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code("0")
+                .message("해시태그 수정에 성공했습니다.")
+                .build(),
+            HttpStatus.OK
+        );
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResDTO<Object>> deleteBy(
+        @PathVariable UUID id
+    ) {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code("0")
+                .message("해시태그 삭제에 성공했습니다.")
+                .build(),
+            HttpStatus.OK
+        );
+    }
+}

--- a/post/src/test/java/com/bookstore/post/httpClient/hashtag.http
+++ b/post/src/test/java/com/bookstore/post/httpClient/hashtag.http
@@ -1,0 +1,28 @@
+### 1. 해시태그 생성
+POST http://localhost:8080/v1/hashtags
+Content-Type: application/json
+
+{
+  "hashtag": {
+    "name": "해시태그 테스트"
+  }
+}
+
+### 2. 해시태그 단건 조회
+GET http://localhost:8080/v1/hashtags/376df3fd-f172-4046-8bd2-9ab22b9c79cd
+
+### 3. 해시태그 리스트 조회
+GET http://localhost:8080/v1/hashtags
+
+### 4. 해시태그 수정
+PUT http://localhost:8080/v1/hashtags/376df3fd-f172-4046-8bd2-9ab22b9c79cd
+Content-Type: application/json
+
+{
+  "hashtag": {
+    "name": "해시태그 업데이트"
+  }
+}
+
+### 5. 해시태그 삭제
+DELETE http://localhost:8080/v1/hashtags/376df3fd-f172-4046-8bd2-9ab22b9c79cd


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 해시태그 Entity 생성
- 해시태그 생성 controller, dto 생성
- 해시태그 단건 조회 controller, dto 생성
- 해시태그 리스트 조회 controller, dto 생성
- 해시태그 수정 controller, dto 생성
- 해시태그 삭제 controller 생성
- 해시태그 CRUD http 테스트 추가

### 테스트 결과
![스크린샷 2025-06-06 오후 3 01 06](https://github.com/user-attachments/assets/e927897f-79da-4501-80fd-a904b03f85e6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 해시태그 생성, 조회(단일/목록), 수정, 삭제를 위한 새로운 API 엔드포인트가 추가되었습니다.
    - 해시태그 관련 요청 및 응답을 위한 데이터 전송 객체(DTO)가 도입되었습니다.
    - 해시태그 정보를 데이터베이스에 저장할 수 있는 엔터티가 추가되었습니다.
    - 해시태그 API 사용 예시를 위한 HTTP 클라이언트 테스트 파일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->