### PR TITLE
✨ feat [#24-post] BaseEntity 추가, 해시태그 예외 코드 및 삭제 구현

### DIFF
--- a/post/src/main/java/com/bookstore/post/hashtag/application/exception/HashtagExceptionCode.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/exception/HashtagExceptionCode.java
@@ -1,0 +1,17 @@
+package com.bookstore.post.hashtag.application.exception;
+
+import com.bookstore.common.application.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HashtagExceptionCode implements ExceptionCode {
+    HASHTAG_NOT_FOUND("H101", "해당 해시태그를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/post/src/main/java/com/bookstore/post/hashtag/application/service/v1/HashtagServiceApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/service/v1/HashtagServiceApiV1.java
@@ -18,4 +18,6 @@ public interface HashtagServiceApiV1 {
     ResHashtagGetDTOApiV1 getBy(Predicate predicate, Pageable pageable);
 
     ResHashtagPutDTOApiV1 putBy(UUID id, ReqHashtagPutDTOApiV1 dto);
+
+    void deleteBy(UUID id);
 }

--- a/post/src/main/java/com/bookstore/post/hashtag/application/service/v1/HashtagServiceImplApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/application/service/v1/HashtagServiceImplApiV1.java
@@ -1,11 +1,13 @@
 package com.bookstore.post.hashtag.application.service.v1;
 
+import com.bookstore.common.application.exception.CustomException;
 import com.bookstore.post.hashtag.application.dto.v1.request.ReqHashtagPostDTOApiV1;
 import com.bookstore.post.hashtag.application.dto.v1.request.ReqHashtagPutDTOApiV1;
 import com.bookstore.post.hashtag.application.dto.v1.response.ResHashtagGetByIdDTOApiV1;
 import com.bookstore.post.hashtag.application.dto.v1.response.ResHashtagGetDTOApiV1;
 import com.bookstore.post.hashtag.application.dto.v1.response.ResHashtagPostDTOApiV1;
 import com.bookstore.post.hashtag.application.dto.v1.response.ResHashtagPutDTOApiV1;
+import com.bookstore.post.hashtag.application.exception.HashtagExceptionCode;
 import com.bookstore.post.hashtag.domain.entity.HashtagEntity;
 import com.bookstore.post.hashtag.domain.repository.HashtagRepository;
 import com.querydsl.core.types.Predicate;
@@ -50,7 +52,15 @@ public class HashtagServiceImplApiV1 implements HashtagServiceApiV1 {
         return ResHashtagPutDTOApiV1.of(updateHashtagEntity);
     }
 
+    @Override
+    @Transactional
+    public void deleteBy(UUID id) {
+        HashtagEntity hashtagEntity = findById(id);
+        hashtagEntity.delete(1L);
+    }
+
     private HashtagEntity findById(UUID id) {
-        return hashtagRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Hashtag not found"));
+        return hashtagRepository.findById(id)
+            .orElseThrow(() -> new CustomException(HashtagExceptionCode.HASHTAG_NOT_FOUND));
     }
 }

--- a/post/src/main/java/com/bookstore/post/hashtag/domain/entity/HashtagEntity.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/domain/entity/HashtagEntity.java
@@ -1,5 +1,6 @@
 package com.bookstore.post.hashtag.domain.entity;
 
+import com.bookstore.common.domain.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "p_hashtags")
-public class HashtagEntity {
+public class HashtagEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;

--- a/post/src/main/java/com/bookstore/post/hashtag/presentation/controller/v1/HashtagControllerApiV1.java
+++ b/post/src/main/java/com/bookstore/post/hashtag/presentation/controller/v1/HashtagControllerApiV1.java
@@ -99,6 +99,7 @@ public class HashtagControllerApiV1 {
     public ResponseEntity<ResDTO<Object>> deleteBy(
         @PathVariable UUID id
     ) {
+        hashtagService.deleteBy(id);
         return new ResponseEntity<>(
             ResDTO.builder()
                 .code("0")

--- a/post/src/main/java/com/bookstore/post/post/domain/entity/PostEntity.java
+++ b/post/src/main/java/com/bookstore/post/post/domain/entity/PostEntity.java
@@ -1,5 +1,6 @@
 package com.bookstore.post.post.domain.entity;
 
+import com.bookstore.common.domain.entity.BaseEntity;
 import com.bookstore.post.post.domain.vo.PostStatus;
 import com.bookstore.post.post.domain.vo.ProductCondition;
 import jakarta.persistence.Column;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "p_posts")
-public class PostEntity {
+public class PostEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 해시태그 삭제 서비스 구현
- 해시태그 관련 예외 코드 작성
- hashtag, post 엔티티에 baseEntity 추가

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 해시태그 삭제 기능이 추가되었습니다.

- **버그 수정**
    - 존재하지 않는 해시태그 삭제 시, 보다 명확한 에러 메시지가 제공됩니다.

- **리팩토링**
    - 해시태그 및 게시글 엔티티가 공통 베이스 엔티티를 상속하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->