### PR TITLE
✨ feat [#43-wish] 찜 생성 구현

### DIFF
--- a/wish/build.gradle
+++ b/wish/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.0'
+	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -19,14 +19,35 @@ configurations {
 	}
 }
 
+ext {
+	set('springCloudVersion', "2024.0.0")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter'
+
+	//feignClient
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
 	implementation 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'com.github.5iobook:common:1.2.0'
+
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/wish/src/main/java/com/bookstore/wish/WishApplication.java
+++ b/wish/src/main/java/com/bookstore/wish/WishApplication.java
@@ -2,7 +2,9 @@ package com.bookstore.wish;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class WishApplication {
 

--- a/wish/src/main/java/com/bookstore/wish/application/dto/v1/response/ResWishPostDTOApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/application/dto/v1/response/ResWishPostDTOApiV1.java
@@ -1,0 +1,35 @@
+package com.bookstore.wish.application.dto.v1.response;
+
+import com.bookstore.wish.domain.entity.WishEntity;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResWishPostDTOApiV1 {
+    private Wish wish;
+
+    public static ResWishPostDTOApiV1 of(WishEntity wishEntity) {
+        return ResWishPostDTOApiV1.builder()
+            .wish(Wish.from(wishEntity))
+            .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Wish {
+        private Long userId;
+        private UUID postId;
+        private LocalDateTime createdAt;
+
+        private static Wish from(WishEntity wishEntity) {
+            return Wish.builder()
+                .userId(wishEntity.getUserId())
+                .postId(wishEntity.getPostId())
+                .createdAt(wishEntity.getCreatedAt())
+                .build();
+        }
+    }
+}

--- a/wish/src/main/java/com/bookstore/wish/application/exception/WishExceptionCode.java
+++ b/wish/src/main/java/com/bookstore/wish/application/exception/WishExceptionCode.java
@@ -1,0 +1,17 @@
+package com.bookstore.wish.application.exception;
+
+import com.bookstore.common.application.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum WishExceptionCode implements ExceptionCode {
+    ALREADY_WISHED("W101", "이미 찜한 게시물입니다.", HttpStatus.CONFLICT),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceApiV1.java
@@ -1,0 +1,9 @@
+package com.bookstore.wish.application.service.v1;
+
+import com.bookstore.wish.application.dto.v1.response.ResWishPostDTOApiV1;
+import java.util.UUID;
+
+public interface WishServiceApiV1 {
+
+    ResWishPostDTOApiV1 postBy(UUID postId);
+}

--- a/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceImplApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceImplApiV1.java
@@ -1,0 +1,33 @@
+package com.bookstore.wish.application.service.v1;
+
+import com.bookstore.common.application.exception.CustomException;
+import com.bookstore.wish.application.dto.v1.response.ResWishPostDTOApiV1;
+import com.bookstore.wish.application.exception.WishExceptionCode;
+import com.bookstore.wish.domain.entity.WishEntity;
+import com.bookstore.wish.domain.repository.WishRepository;
+import com.bookstore.wish.infrastructure.client.PostFeignClientApiV1;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WishServiceImplApiV1 implements WishServiceApiV1 {
+
+    private final WishRepository wishRepository;
+    private final PostFeignClientApiV1 postFeignClientApiV1;
+
+    @Override
+    @Transactional
+    public ResWishPostDTOApiV1 postBy(UUID postId) {
+        postFeignClientApiV1.getBy(postId);
+
+        if (wishRepository.existsByUserIdAndPostId(1L, postId)) {
+            throw new CustomException(WishExceptionCode.ALREADY_WISHED);
+        }
+        WishEntity wishEntity = wishRepository.save(WishEntity.create(1L, postId));
+        return ResWishPostDTOApiV1.of(wishEntity);
+    }
+}

--- a/wish/src/main/java/com/bookstore/wish/domain/entity/WishEntity.java
+++ b/wish/src/main/java/com/bookstore/wish/domain/entity/WishEntity.java
@@ -1,0 +1,54 @@
+package com.bookstore.wish.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "p_wishes")
+public class WishEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "post_id")
+    private UUID postId;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private WishEntity(
+        Long userId,
+        UUID postId
+    ) {
+        this.userId = userId;
+        this.postId = postId;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static WishEntity create(
+        Long userId,
+        UUID postId
+    ) {
+        return WishEntity.builder()
+            .userId(userId)
+            .postId(postId)
+            .build();
+    }
+}

--- a/wish/src/main/java/com/bookstore/wish/domain/repository/WishRepository.java
+++ b/wish/src/main/java/com/bookstore/wish/domain/repository/WishRepository.java
@@ -1,0 +1,10 @@
+package com.bookstore.wish.domain.repository;
+
+import com.bookstore.wish.domain.entity.WishEntity;
+import java.util.UUID;
+
+public interface WishRepository {
+    boolean existsByUserIdAndPostId(Long userId, UUID postId);
+
+    WishEntity save(WishEntity wishEntity);
+}

--- a/wish/src/main/java/com/bookstore/wish/infrastructure/client/PostFeignClientApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/infrastructure/client/PostFeignClientApiV1.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "postClient", url = "localhost:8081")
+@FeignClient(name = "postClient", url = "http://localhost:8081")
 public interface PostFeignClientApiV1 {
 
     @GetMapping("/v1/posts/{id}")

--- a/wish/src/main/java/com/bookstore/wish/infrastructure/client/PostFeignClientApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/infrastructure/client/PostFeignClientApiV1.java
@@ -1,0 +1,17 @@
+package com.bookstore.wish.infrastructure.client;
+
+import com.bookstore.common.application.dto.ResDTO;
+import com.bookstore.wish.infrastructure.client.dto.ResPostGetByIdDTOApiV1;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "postClient", url = "localhost:8081")
+public interface PostFeignClientApiV1 {
+
+    @GetMapping("/v1/posts/{id}")
+    ResponseEntity<ResDTO<ResPostGetByIdDTOApiV1>> getBy(@PathVariable UUID id);
+
+}

--- a/wish/src/main/java/com/bookstore/wish/infrastructure/client/dto/ResPostGetByIdDTOApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/infrastructure/client/dto/ResPostGetByIdDTOApiV1.java
@@ -1,0 +1,40 @@
+package com.bookstore.wish.infrastructure.client.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResPostGetByIdDTOApiV1 {
+    private Post post;
+
+    @Getter
+    @Builder
+    public static class Post {
+        private String content;
+        private String title;
+        private Price price;
+        private String status;
+        private String condition;
+        private int viewCount;
+        private int wishCount;
+        private List<Hashtag> hashtagList;
+
+        @Getter
+        @Builder
+        public static class Hashtag {
+            private String name;
+        }
+
+        @Getter
+        @Builder
+        public static class Price {
+            private int amount;
+        }
+    }
+}

--- a/wish/src/main/java/com/bookstore/wish/infrastructure/persistence/WishJpaRepository.java
+++ b/wish/src/main/java/com/bookstore/wish/infrastructure/persistence/WishJpaRepository.java
@@ -1,0 +1,10 @@
+package com.bookstore.wish.infrastructure.persistence;
+
+import com.bookstore.wish.domain.entity.WishEntity;
+import com.bookstore.wish.domain.repository.WishRepository;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WishJpaRepository extends JpaRepository<WishEntity, UUID>, WishRepository {
+
+}

--- a/wish/src/main/java/com/bookstore/wish/presentation/controller/v1/WishControllerApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/presentation/controller/v1/WishControllerApiV1.java
@@ -1,0 +1,63 @@
+package com.bookstore.wish.presentation.controller.v1;
+
+import com.bookstore.common.application.dto.ResDTO;
+import com.bookstore.wish.application.dto.v1.response.ResWishPostDTOApiV1;
+import com.bookstore.wish.application.service.v1.WishServiceApiV1;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/wishes")
+public class WishControllerApiV1 {
+
+    private final WishServiceApiV1 wishService;
+
+    @PostMapping
+    public ResponseEntity<ResDTO<ResWishPostDTOApiV1>> postBy(
+        @RequestParam UUID postId
+    ) {
+        ResWishPostDTOApiV1 response = wishService.postBy(postId);
+        return new ResponseEntity<>(
+            ResDTO.<ResWishPostDTOApiV1>builder()
+                .code("0")
+                .message("위시에 추가되었습니다.")
+                .data(response)
+                .build(),
+            HttpStatus.CREATED
+        );
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ResDTO<Object>> getBy() {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code("0")
+                .message("사용자 위시 리스트 조회에 성공했습니다.")
+                .build(),
+            HttpStatus.OK
+        );
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResDTO<Object>> deleteBy(
+        @PathVariable UUID id
+    ) {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code("0")
+                .message("위시를 취소했습니다.")
+                .build(),
+            HttpStatus.NO_CONTENT
+        );
+    }
+}

--- a/wish/src/main/resources/application-dev.yml
+++ b/wish/src/main/resources/application-dev.yml
@@ -15,3 +15,13 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+
+server:
+  port: 8082

--- a/wish/src/test/java/com/bookstore/wish/httpClient/wish.http
+++ b/wish/src/test/java/com/bookstore/wish/httpClient/wish.http
@@ -1,0 +1,2 @@
+### 1. 찜 생성
+POST http://localhost:8082/v1/wishes?postId=a3b34a91-8fc3-4ed3-b95c-d6d9a04228ca


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과

![스크린샷 2025-06-18 오후 3 15 57](https://github.com/user-attachments/assets/1daed6d4-af53-48db-8056-b7daae765057)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 찜(위시) 생성, 조회, 취소를 위한 REST API 엔드포인트가 추가되었습니다.
  - 외부 포스트 서비스와 연동하여 포스트 정보 검증 및 연동이 가능합니다.
  - 사용자가 이미 찜한 포스트에 중복 찜 시도 시 오류 메시지가 반환됩니다.
  - Eureka 클라이언트 및 OpenFeign 연동이 적용되어 서비스 간 통신 및 서비스 등록이 지원됩니다.

- **테스트**
  - 찜 생성(POST /v1/wishes) 요청을 위한 HTTP 클라이언트 테스트 스니펫이 추가되었습니다.

- **설정**
  - Eureka 클라이언트 및 서버 포트(8082) 설정이 추가되었습니다.
  - Spring Cloud 및 의존성 관련 설정이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->