### PR TITLE
✨ feat [#49 wish] 본인 찜 목록 조회 및 찜 취소 구현

### DIFF
--- a/wish/src/main/java/com/bookstore/wish/application/dto/v1/response/ResWishGetDTOApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/application/dto/v1/response/ResWishGetDTOApiV1.java
@@ -1,0 +1,58 @@
+package com.bookstore.wish.application.dto.v1.response;
+
+import com.bookstore.wish.domain.entity.WishEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
+
+@Getter
+@Builder
+public class ResWishGetDTOApiV1 {
+    private WishPage wishPage;
+
+    public static ResWishGetDTOApiV1 of(
+        Page<WishEntity> wishEntityPage
+    ) {
+        return ResWishGetDTOApiV1.builder()
+            .wishPage(new WishPage(wishEntityPage))
+            .build();
+    }
+
+    @Getter
+    public static class WishPage extends PagedModel<WishPage.Wish> {
+        public WishPage(Page<WishEntity> wishEntityPage) {
+            super(
+                new PageImpl<>(
+                    Wish.from(wishEntityPage.getContent()),
+                    wishEntityPage.getPageable(),
+                    wishEntityPage.getTotalElements()
+                )
+            );
+        }
+
+        @Getter
+        @Builder
+        public static class Wish {
+            private UUID postId;
+            private LocalDateTime createdAt;
+
+            public static List<Wish> from(List<WishEntity> wishEntityList) {
+                return wishEntityList.stream()
+                    .map(Wish::from)
+                    .toList();
+            }
+
+            public static Wish from(WishEntity wishEntity) {
+                return Wish.builder()
+                    .postId(wishEntity.getPostId())
+                    .createdAt(wishEntity.getCreatedAt())
+                    .build();
+            }
+        }
+    }
+}

--- a/wish/src/main/java/com/bookstore/wish/application/exception/WishExceptionCode.java
+++ b/wish/src/main/java/com/bookstore/wish/application/exception/WishExceptionCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum WishExceptionCode implements ExceptionCode {
     ALREADY_WISHED("W101", "이미 찜한 게시물입니다.", HttpStatus.CONFLICT),
+    WISH_NOT_FOUND("W102", "찜 목록에 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_OWN_WISH("W103", "본인의 찜이 아닙니다.", HttpStatus.FORBIDDEN),
     ;
 
     private final String code;

--- a/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceApiV1.java
@@ -1,9 +1,15 @@
 package com.bookstore.wish.application.service.v1;
 
+import com.bookstore.wish.application.dto.v1.response.ResWishGetDTOApiV1;
 import com.bookstore.wish.application.dto.v1.response.ResWishPostDTOApiV1;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 
 public interface WishServiceApiV1 {
 
     ResWishPostDTOApiV1 postBy(UUID postId);
+
+    ResWishGetDTOApiV1 getBy(Long userId, Pageable pageable);
+
+    void deleteBy(Long userId, UUID id);
 }

--- a/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceImplApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceImplApiV1.java
@@ -1,6 +1,7 @@
 package com.bookstore.wish.application.service.v1;
 
 import com.bookstore.common.application.exception.CustomException;
+import com.bookstore.wish.application.dto.v1.response.ResWishGetDTOApiV1;
 import com.bookstore.wish.application.dto.v1.response.ResWishPostDTOApiV1;
 import com.bookstore.wish.application.exception.WishExceptionCode;
 import com.bookstore.wish.domain.entity.WishEntity;
@@ -8,6 +9,8 @@ import com.bookstore.wish.domain.repository.WishRepository;
 import com.bookstore.wish.infrastructure.client.PostFeignClientApiV1;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,5 +32,24 @@ public class WishServiceImplApiV1 implements WishServiceApiV1 {
         }
         WishEntity wishEntity = wishRepository.save(WishEntity.create(1L, postId));
         return ResWishPostDTOApiV1.of(wishEntity);
+    }
+
+    @Override
+    public ResWishGetDTOApiV1 getBy(Long userId, Pageable pageable) {
+        Page<WishEntity> wishList = wishRepository.findAllByUserId(userId, pageable);
+        return ResWishGetDTOApiV1.of(wishList);
+    }
+
+    @Override
+    @Transactional
+    public void deleteBy(Long userId, UUID id) {
+        WishEntity wishEntity = wishRepository.findById(id)
+            .orElseThrow(() -> new CustomException(WishExceptionCode.WISH_NOT_FOUND));
+
+        if (!wishEntity.isOwnedBy(userId)) {
+            throw new CustomException(WishExceptionCode.NOT_OWN_WISH);
+        }
+
+        wishRepository.deleteById(id);
     }
 }

--- a/wish/src/main/java/com/bookstore/wish/domain/entity/WishEntity.java
+++ b/wish/src/main/java/com/bookstore/wish/domain/entity/WishEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -53,6 +54,6 @@ public class WishEntity {
     }
 
     public boolean isOwnedBy(Long userId) {
-        return this.userId.equals(userId);
+        return Objects.equals(this.userId, userId);
     }
 }

--- a/wish/src/main/java/com/bookstore/wish/domain/entity/WishEntity.java
+++ b/wish/src/main/java/com/bookstore/wish/domain/entity/WishEntity.java
@@ -51,4 +51,8 @@ public class WishEntity {
             .postId(postId)
             .build();
     }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
 }

--- a/wish/src/main/java/com/bookstore/wish/domain/repository/WishRepository.java
+++ b/wish/src/main/java/com/bookstore/wish/domain/repository/WishRepository.java
@@ -1,10 +1,19 @@
 package com.bookstore.wish.domain.repository;
 
 import com.bookstore.wish.domain.entity.WishEntity;
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface WishRepository {
     boolean existsByUserIdAndPostId(Long userId, UUID postId);
 
     WishEntity save(WishEntity wishEntity);
+
+    Page<WishEntity> findAllByUserId(Long userId, Pageable pageable);
+
+    Optional<WishEntity> findById(UUID id);
+
+    void deleteById(UUID id);
 }

--- a/wish/src/main/java/com/bookstore/wish/presentation/controller/v1/WishControllerApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/presentation/controller/v1/WishControllerApiV1.java
@@ -1,10 +1,13 @@
 package com.bookstore.wish.presentation.controller.v1;
 
 import com.bookstore.common.application.dto.ResDTO;
+import com.bookstore.wish.application.dto.v1.response.ResWishGetDTOApiV1;
 import com.bookstore.wish.application.dto.v1.response.ResWishPostDTOApiV1;
 import com.bookstore.wish.application.service.v1.WishServiceApiV1;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -38,11 +41,15 @@ public class WishControllerApiV1 {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ResDTO<Object>> getBy() {
+    public ResponseEntity<ResDTO<ResWishGetDTOApiV1>> getBy(
+        @PageableDefault(page = 0, size = 10) Pageable pageable
+    ) {
+        ResWishGetDTOApiV1 response = wishService.getBy(1L, pageable);
         return new ResponseEntity<>(
-            ResDTO.builder()
+            ResDTO.<ResWishGetDTOApiV1>builder()
                 .code("0")
                 .message("사용자 위시 리스트 조회에 성공했습니다.")
+                .data(response)
                 .build(),
             HttpStatus.OK
         );
@@ -52,12 +59,13 @@ public class WishControllerApiV1 {
     public ResponseEntity<ResDTO<Object>> deleteBy(
         @PathVariable UUID id
     ) {
+        wishService.deleteBy(1L, id);
         return new ResponseEntity<>(
             ResDTO.builder()
                 .code("0")
                 .message("위시를 취소했습니다.")
                 .build(),
-            HttpStatus.NO_CONTENT
+            HttpStatus.OK
         );
     }
 }

--- a/wish/src/test/java/com/bookstore/wish/httpClient/wish.http
+++ b/wish/src/test/java/com/bookstore/wish/httpClient/wish.http
@@ -1,2 +1,8 @@
 ### 1. 찜 생성
 POST http://localhost:8082/v1/wishes?postId=a3b34a91-8fc3-4ed3-b95c-d6d9a04228ca
+
+### 2. 사용자 ID 기반 찜 목록 조회
+GET http://localhost:8082/v1/wishes/me
+
+### 3. 위시 취소
+DELETE http://localhost:8082/v1/wishes/84417f05-9bf0-4d1d-a1fa-2123e042419d


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
본인 찜 목록 조회
본인 여부 확인 후 찜 취소

### 테스트 결과
![스크린샷 2025-06-19 오후 2 35 58](https://github.com/user-attachments/assets/21d8113c-ce41-4d88-8547-833d4d8ea632)
![스크린샷 2025-06-19 오후 2 47 18](https://github.com/user-attachments/assets/13e2d405-46ae-4c82-aab0-355599f1e5a9)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자의 찜 목록을 페이지네이션 형태로 조회할 수 있는 기능이 추가되었습니다.
  - 찜 항목을 개별적으로 삭제할 수 있는 기능이 추가되었습니다.

- **버그 수정**
  - 삭제 요청 시 응답 코드가 204에서 200으로 변경되고, 성공 메시지가 포함됩니다.

- **테스트**
  - 찜 목록 조회 및 삭제에 대한 HTTP 예제 요청이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->