### PR TITLE
✨ feat [#52-post-wish] 게시글 찜 수 증감 기능 구현

### DIFF
--- a/post/src/main/java/com/bookstore/post/post/application/service/v1/PostServiceApiV1.java
+++ b/post/src/main/java/com/bookstore/post/post/application/service/v1/PostServiceApiV1.java
@@ -22,4 +22,8 @@ public interface PostServiceApiV1 {
     void deleteBy(UUID id);
 
     void existsBy(UUID id);
+
+    void increaseWishCount(UUID id);
+
+    void decreaseWishCount(UUID id);
 }

--- a/post/src/main/java/com/bookstore/post/post/application/service/v1/PostServiceImplApiV1.java
+++ b/post/src/main/java/com/bookstore/post/post/application/service/v1/PostServiceImplApiV1.java
@@ -103,6 +103,18 @@ public class PostServiceImplApiV1 implements PostServiceApiV1 {
         findPostById(id);
     }
 
+    @Override
+    @Transactional
+    public void increaseWishCount(UUID id) {
+        findPostById(id).incrementWishCount();
+    }
+
+    @Override
+    @Transactional
+    public void decreaseWishCount(UUID id) {
+        findPostById(id).decreaseWishCount();
+    }
+
     private PostEntity findPostById(UUID id) {
         return postRepository.findById(id)
             .orElseThrow(() -> new CustomException(PostExceptionCode.POST_NOT_FOUND));

--- a/post/src/main/java/com/bookstore/post/post/domain/entity/PostEntity.java
+++ b/post/src/main/java/com/bookstore/post/post/domain/entity/PostEntity.java
@@ -127,4 +127,12 @@ public class PostEntity extends BaseEntity {
     public void incrementViewCount() {
         viewCount++;
     }
+
+    public void incrementWishCount() {
+        wishCount++;
+    }
+
+    public void decreaseWishCount() {
+        wishCount--;
+    }
 }

--- a/post/src/main/java/com/bookstore/post/post/presentation/controller/v1/InternalPostController.java
+++ b/post/src/main/java/com/bookstore/post/post/presentation/controller/v1/InternalPostController.java
@@ -1,0 +1,39 @@
+package com.bookstore.post.post.presentation.controller.v1;
+
+import com.bookstore.post.post.application.service.v1.PostServiceApiV1;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/internal/posts")
+public class InternalPostController {
+
+    private final PostServiceApiV1 postService;
+
+    @GetMapping("/{id}/exists")
+    public void existsBy(
+        @PathVariable UUID id
+    ) {
+        postService.existsBy(id);
+    }
+
+    @PostMapping("/{id}/wish-count/increase")
+    public void increaseWishCount(
+        @PathVariable UUID id
+    ) {
+        postService.increaseWishCount(id);
+    }
+
+    @PostMapping("/{id}/wish-count/decrease")
+    public void decreaseWishCount(
+        @PathVariable UUID id
+    ) {
+        postService.decreaseWishCount(id);
+    }
+}

--- a/post/src/main/java/com/bookstore/post/post/presentation/controller/v1/PostControllerApiV1.java
+++ b/post/src/main/java/com/bookstore/post/post/presentation/controller/v1/PostControllerApiV1.java
@@ -108,12 +108,4 @@ public class PostControllerApiV1 {
             HttpStatus.NO_CONTENT
         );
     }
-
-    @GetMapping("/{id}/exists")
-    public ResponseEntity<Void> existsBy(
-        @PathVariable UUID id
-    ) {
-        postService.existsBy(id);
-        return ResponseEntity.ok().build();
-    }
 }

--- a/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceImplApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/application/service/v1/WishServiceImplApiV1.java
@@ -30,7 +30,10 @@ public class WishServiceImplApiV1 implements WishServiceApiV1 {
         if (wishRepository.existsByUserIdAndPostId(1L, postId)) {
             throw new CustomException(WishExceptionCode.ALREADY_WISHED);
         }
+
         WishEntity wishEntity = wishRepository.save(WishEntity.create(1L, postId));
+        postFeignClientApiV1.increaseWishCount(postId);
+
         return ResWishPostDTOApiV1.of(wishEntity);
     }
 
@@ -51,5 +54,6 @@ public class WishServiceImplApiV1 implements WishServiceApiV1 {
         }
 
         wishRepository.deleteById(id);
+        postFeignClientApiV1.decreaseWishCount(wishEntity.getPostId());
     }
 }

--- a/wish/src/main/java/com/bookstore/wish/infrastructure/client/PostFeignClientApiV1.java
+++ b/wish/src/main/java/com/bookstore/wish/infrastructure/client/PostFeignClientApiV1.java
@@ -2,14 +2,20 @@ package com.bookstore.wish.infrastructure.client;
 
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @FeignClient(name = "postClient", url = "http://localhost:8081")
 public interface PostFeignClientApiV1 {
 
-    @GetMapping("/v1/posts/{id}/exists")
-    ResponseEntity<Void> existsBy(@PathVariable UUID id);
+    @GetMapping("/v1/internal/posts/{id}/exists")
+    void existsBy(@PathVariable UUID id);
+
+    @PostMapping("/v1/internal/posts/{id}/wish-count/increase")
+    void increaseWishCount(@PathVariable UUID id);
+
+    @PostMapping("/v1/internal/posts/{id}/wish-count/decrease")
+    void decreaseWishCount(@PathVariable UUID id);
 
 }


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 내부 통신용 게시글 컨트롤러 추가
- 찜 수 증가/감소 API 구현
- Wish 서비스에 Post 찜 수 증감 요청 Feign Client 구현

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 게시글의 찜(wish) 수를 증가 및 감소시키는 기능이 추가되었습니다.
    - 게시글 존재 여부 확인 및 찜 수 조작을 위한 내부 전용 API 엔드포인트가 도입되었습니다.

- **버그 수정**
    - 찜 생성 또는 삭제 시 게시글의 찜 수가 자동으로 동기화되도록 개선되었습니다.

- **API 변경**
    - 게시글 존재 여부 확인 및 찜 수 조작을 위한 엔드포인트 경로와 응답 형식이 일부 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->